### PR TITLE
Use the simde header library for non-x86 compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/simde"]
+	path = src/simde
+	url = https://github.com/nemequ/simde-no-tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if (debug)
     set (LIBRARY_COMPILE_DEFINITIONS  "${LIBRARY_COMPILE_DEFINITIONS} -g -p")
     message("-- COMPILATION IN DEBUG MODE")
 else()
-    set (LIBRARY_COMPILE_DEFINITIONS  "${LIBRARY_COMPILE_DEFINITIONS} -O3 -funroll-loops  -fomit-frame-pointer  -msse3 ")
+    set (LIBRARY_COMPILE_DEFINITIONS  "${LIBRARY_COMPILE_DEFINITIONS} -O3 -funroll-loops  -fomit-frame-pointer")
 #  -DOBSFUCATION  -DJNI_OBSFUCATION
 endif()
 

--- a/src/algo/hits/gap/SmallGapHitIteratorSSE8.cpp
+++ b/src/algo/hits/gap/SmallGapHitIteratorSSE8.cpp
@@ -19,15 +19,8 @@
 
 #include <algo/hits/gap/SmallGapHitIteratorSSE8.hpp>
 
-#if __SSE3__
-    #include <pmmintrin.h>
-#else
-    #if __SSE2__
-        #include <emmintrin.h>
-    #else
-        #warning error undefined __SSE3__ or __SSE2__
-    #endif
-#endif
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse3.h>
 
 using namespace std;
 using namespace misc;

--- a/src/algo/hits/ungap/UngapHitIteratorSSE16.cpp
+++ b/src/algo/hits/ungap/UngapHitIteratorSSE16.cpp
@@ -21,15 +21,8 @@
 
 #include <algo/hits/ungap/UngapHitIteratorSSE16.hpp>
 
-#if __SSE3__
-    #include <pmmintrin.h>
-#else
-#if __SSE2__
-    #include <emmintrin.h>
-#else
-    #warning error undefined __SSE3__ or __SSE2__
-#endif
-#endif
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse3.h>
 
 using namespace std;
 using namespace misc;

--- a/src/algo/hits/ungap/UngapHitIteratorSSE8.cpp
+++ b/src/algo/hits/ungap/UngapHitIteratorSSE8.cpp
@@ -20,15 +20,8 @@
 
 #include <algo/hits/ungap/UngapHitIteratorSSE8.hpp>
 
-#if __SSE3__
-    #include <pmmintrin.h>
-#else
-#if __SSE2__
-    #include <emmintrin.h>
-#else
-    #warning error undefined __SSE3__ or __SSE2__
-#endif
-#endif
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse3.h>
 
 using namespace std;
 using namespace misc;


### PR DESCRIPTION
Currently, plast builds only on x86 arches, using simde, I've attempted to make it build across more arches.

Achieved success on: amd64, arm64, armhf, armel, mipel, mips64el, i386, riscv64 and several other arches.

cc: @ivajloip @cdeltel 